### PR TITLE
Ignore .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /doc/
 /log/
 /.fetch
+.env
 erl_crash.dump
 *.ez
 alert-*.tar


### PR DESCRIPTION
It's not secure to have an ability to commit a .env file, which can contain sensitive info.